### PR TITLE
Fixed MatchStar

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,10 @@
+Updates: Organized the codes packages to be functional, fixed the code so
+all tests pass, and fixed a glitch which prevented operations from being
+used in tandem.
+
+-Abiel F.
+
+-------------------------------------------------------------------------
 # RegEx 
 
 This is a simple Java implementation of the C algorithm in the

--- a/java/pikematcher/src/main/java/rocks/zipcode/Guts.java
+++ b/java/pikematcher/src/main/java/rocks/zipcode/Guts.java
@@ -1,3 +1,5 @@
+package main.java.rocks.zipcode;
+
 public class Guts {
 
     private char regex[] = null;

--- a/java/pikematcher/src/main/java/rocks/zipcode/PikeMatcher.java
+++ b/java/pikematcher/src/main/java/rocks/zipcode/PikeMatcher.java
@@ -1,4 +1,4 @@
-/*
+package main.java.rocks.zipcode;/*
 PikeMatcher.java
 
  https://www.cs.princeton.edu/courses/archive/spr09/cos333/beautiful.html
@@ -8,14 +8,21 @@ PikeMatcher.java
 
 public class PikeMatcher {
 
+
+    public PikeMatcher(){}
+
     /* match: search for regexp anywhere in text */
     public boolean match(String regexp, String text) {
         if (regexp.charAt(0) == '^')
             return matchhere(regexp.substring(1), text);
         do {    /* must look even if string is empty */
             if (matchhere(regexp, text))
+                //This means we found at least one instance of the regex in the text
                 return true;
+            //this means we did NOT find the occurance at the beginning of the text,
+            //so we substring it out and search at the next
             text = text.substring(1);
+            //We do this until there is no more text, which lets us exit the do while
         } while (!text.equals(""));
         return false;
     }
@@ -23,26 +30,34 @@ public class PikeMatcher {
     /* matchhere: search for regexp at beginning of text */
     public boolean matchhere(String regexp, String text) {
         if (regexp.equals(""))
+            //No regex left means a complete match has been found, return true.
             return true;
         if (regexp.length() > 1 && regexp.charAt(1) == '*')
+            //implements stars. Stars MUST be the second character for a regex.
             return matchstar(regexp.charAt(0), regexp.substring(2), text);
         if (regexp.charAt(0) == '$' && regexp.length() == 1)
+            //Checks for dollarsign regex being the last character
             return text.equals("");
-        if (text != "" && (regexp.charAt(0) == '.' || regexp.charAt(0)== text.charAt(0)))
+        if (!text.equals("") && (regexp.charAt(0) == '.' || regexp.charAt(0)== text.charAt(0)))
+            //if the text isn't done, and if the character were looking at matches
+            // . or the first regex charatcer, then continue with the next parts
+            // of the reg and string to confirm complete match
             return matchhere(regexp.substring(1), text.substring(1));
         return false;
     }
 
     /* matchstar: search for c*regexp at beginning of text */
     public boolean matchstar(char c, String regexp, String text) {
-        int t = 0;
+
         do {
             if (matchhere(regexp, text) == true) {
                 return true;
             }
-            t++;
+            text=text.substring(1);
+            //I don't think the exit condition is correct,
+            // should lead to prematurely leaving the loop before searching the whole text for a match
         } while (!text.equals("") &&
-                (text.charAt(t) == c || c == '.'));
+                (text.charAt(0) == c || c == '.'));
         return false;
     }
 }

--- a/java/pikematcher/src/main/java/rocks/zipcode/PikeMatcher.java
+++ b/java/pikematcher/src/main/java/rocks/zipcode/PikeMatcher.java
@@ -50,12 +50,11 @@ public class PikeMatcher {
     public boolean matchstar(char c, String regexp, String text) {
 
         do {
+            text=text.substring(1);
             if (matchhere(regexp, text) == true) {
                 return true;
             }
-            text=text.substring(1);
-            //I don't think the exit condition is correct,
-            // should lead to prematurely leaving the loop before searching the whole text for a match
+
         } while (!text.equals("") &&
                 (text.charAt(0) == c || c == '.'));
         return false;

--- a/java/pikematcher/src/test/java/rocks/zipcode/GutsTest.java
+++ b/java/pikematcher/src/test/java/rocks/zipcode/GutsTest.java
@@ -1,3 +1,6 @@
+package test.java.rocks.zipcode;
+
+import main.java.rocks.zipcode.Guts;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -17,8 +20,7 @@ public class GutsTest {
     }
 
     @Test
-    public void testmatch1() {
-        assertEquals(true, foo.match("abc", "abc"));
+    public void testmatch1() { assertEquals(true, foo.match("abc", "abc"));
     }
 
     @Test

--- a/java/pikematcher/src/test/java/rocks/zipcode/GutsTest.java
+++ b/java/pikematcher/src/test/java/rocks/zipcode/GutsTest.java
@@ -62,4 +62,40 @@ public class GutsTest {
         assertEquals(false, foo.match("cb.", "aaabcabcc"));
     }
 
+    @Test
+    public void testmatch10() {
+        assertEquals(true, foo.match(".*cc", "aaabcabcc"));
+    }
+
+
+    @Test
+    public void testmatch11() {
+        assertEquals(true, foo.match("h*bca", "aaabcabcc"));
+    }
+//Testing to ensure guts doesn't have the same bug as PikeMatcher
+    @Test
+    public void testmatch12() {
+        assertEquals(true, foo.match("^a*b", "aaabcabcc"));
+    }
+
+    @Test
+    public void testmatch13() {
+        assertEquals(true, foo.match("^aaab", "aaabcabcc"));
+    }
+    @Test
+    public void testmatch14() {
+        assertEquals(true, foo.match("^a.ab", "aaabcabcc"));
+    }
+    @Test
+    public void testmatch15() {
+        assertEquals(true, foo.match("^.*b", "aaabcabcc"));
+    }
+    @Test
+    public void testmatch16() {
+        assertEquals(true, foo.match("^aabc$", "aabc"));
+    }
+    @Test
+    public void testmatch17() {
+        assertEquals(true, foo.match("^a*bc.*bcc$", "aaabcabcc"));
+    }
 }

--- a/java/pikematcher/src/test/java/rocks/zipcode/TestPikeMatcher.java
+++ b/java/pikematcher/src/test/java/rocks/zipcode/TestPikeMatcher.java
@@ -136,8 +136,6 @@ class PikeMatcherTest {
 
     @Test
     public void testmatch6() {
-        //doesn't work because Star is bugged.
-        // Loop only ends once index is outside array, crashing program
         PikeMatcher foo = new PikeMatcher();
         assertEquals(true, foo.match(".*cc", "aaabcbbcc"));
     }
@@ -162,7 +160,38 @@ class PikeMatcherTest {
     @Test
     public void testmatch10(){
         PikeMatcher foo = new PikeMatcher();
-        assertEquals(true, foo.match("h*cc", "aaabhccabcc"));
+        assertEquals(true, foo.match("h*cc", "ccaaababcc"));
+    }
+    @Test
+    public void testmatch11(){
+        PikeMatcher foo = new PikeMatcher();
+        assertEquals(true, foo.match("h*cc", "aaabhccab"));
+    }
+    @Test
+    public void testmatch12(){
+        PikeMatcher foo = new PikeMatcher();
+        assertEquals(true, foo.match("a*b", "aaabhcabcc"));
+    }
+
+    @Test
+    public void testmatch13(){
+        PikeMatcher foo = new PikeMatcher();
+        assertEquals(true, foo.match("^aaab", "aaab hccabcc"));
+    }
+    @Test
+    public void testmatch14(){
+        PikeMatcher foo = new PikeMatcher();
+        assertEquals(true, foo.match("^a*bbc", "aaaaabbccbbhccabcc"));
+    }
+    @Test
+    public void testmatch15(){
+        PikeMatcher foo = new PikeMatcher();
+        assertEquals(true, foo.match("^c.b", "cabaaaaabcbhccabcc"));
+    }
+    @Test
+    public void testmatch16(){
+        PikeMatcher foo = new PikeMatcher();
+        assertEquals(false, foo.match("^h*bbc", "aaaaabbccbbhccabcc"));
     }
 
 }

--- a/java/pikematcher/src/test/java/rocks/zipcode/TestPikeMatcher.java
+++ b/java/pikematcher/src/test/java/rocks/zipcode/TestPikeMatcher.java
@@ -194,4 +194,36 @@ class PikeMatcherTest {
         assertEquals(false, foo.match("^h*bbc", "aaaaabbccbbhccabcc"));
     }
 
+    @Test
+    public void testmatch17(){
+        PikeMatcher foo = new PikeMatcher();
+        assertEquals(true, foo.match("^a.*bbc", "aaaaabbccbbhccabcc"));
+    }
+
+    @Test
+    public void testmatch18(){
+        PikeMatcher foo = new PikeMatcher();
+        assertEquals(false, foo.match("^a.*bhc", "aaaaabbccbbccabcc"));
+    }
+    @Test
+    public void testmatch19(){
+        PikeMatcher foo = new PikeMatcher();
+        assertEquals(true, foo.match("^abc$", "abc"));
+    }
+    @Test
+    public void testmatch20(){
+        PikeMatcher foo = new PikeMatcher();
+        assertEquals(true, foo.match("^a.c$", "abc"));
+    }
+    @Test
+    public void testmatch21(){
+        PikeMatcher foo = new PikeMatcher();
+        assertEquals(true, foo.match("^a.*c$", "abh219sc"));
+    }
+    @Test
+    public void testmatch22(){
+        PikeMatcher foo = new PikeMatcher();
+        assertEquals(true, foo.match("^a*bc.*bcc$", "aaabcabcc"));
+    }
+
 }

--- a/java/pikematcher/src/test/java/rocks/zipcode/TestPikeMatcher.java
+++ b/java/pikematcher/src/test/java/rocks/zipcode/TestPikeMatcher.java
@@ -1,6 +1,10 @@
-package rocks.zipcode;
+package test.java.rocks.zipcode;
 import static org.junit.jupiter.api.Assertions.*;
-import rocks.zipcode.PikeMatcher;
+
+import org.junit.After;
+import org.junit.Before;
+import main.java.rocks.zipcode.PikeMatcher;
+import org.junit.jupiter.api.Test;
 
 class PikeMatcherTest {
 
@@ -89,7 +93,7 @@ class PikeMatcherTest {
         assertFalse(actual);
     }
 
-    private PikeMatcher foo;
+    /*private PikeMatcher foo;
 
     @Before
     public void setUp() throws Exception {
@@ -98,50 +102,67 @@ class PikeMatcherTest {
 
     @After
     public void tearDown() throws Exception {
-    }
+    }*/
 
     @Test
     public void testmatch1() {
+        PikeMatcher foo = new PikeMatcher();
         assertEquals(true, foo.match("abc", "abc"));
     }
 
     @Test
     public void testmatch2() {
+        PikeMatcher foo = new PikeMatcher();
         assertEquals(true, foo.match("^a", "abc"));
     }
 
     @Test
     public void testmatch3() {
+        PikeMatcher foo = new PikeMatcher();
         assertEquals(false, foo.match("^b", "abc"));
     }
 
-    @Test
+    @org.junit.jupiter.api.Test
     public void testmatch4() {
+        PikeMatcher foo = new PikeMatcher();
         assertEquals(true, foo.match("abc", "aaabcbbcc"));
     }
 
     @Test
     public void testmatch5() {
+        PikeMatcher foo = new PikeMatcher();
         assertEquals(true, foo.match("c$", "aaabcbbcc"));
     }
 
     @Test
     public void testmatch6() {
+        //doesn't work because Star is bugged.
+        // Loop only ends once index is outside array, crashing program
+        PikeMatcher foo = new PikeMatcher();
         assertEquals(true, foo.match(".*cc", "aaabcbbcc"));
     }
 
     @Test
     public void testmatch7() {
+        PikeMatcher foo = new PikeMatcher();
         assertEquals(false, foo.match("jkl", "aaabcbbcc"));
     }
     @Test
     public void testmatch8() {
+        PikeMatcher foo = new PikeMatcher();
         assertEquals(true, foo.match("cb.", "aaabcbbcc"));
     }
 
     @Test
     public void testmatch9() {
+        PikeMatcher foo = new PikeMatcher();
         assertEquals(false, foo.match("cb.", "aaabcabcc"));
+    }
+
+    @Test
+    public void testmatch10(){
+        PikeMatcher foo = new PikeMatcher();
+        assertEquals(true, foo.match("h*cc", "aaabhccabcc"));
     }
 
 }

--- a/pom.xml
+++ b/pom.xml
@@ -17,6 +17,12 @@
             <artifactId>junit</artifactId>
             <version>4.13.1</version>
         </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>RELEASE</version>
+            <scope>compile</scope>
+        </dependency>
     </dependencies>
 
 


### PR DESCRIPTION
Fixed the packages, fixed the two tests that weren't working, and fixed a bug in the matchStar method in pike matcher that didn't let the ^ and * regex work in tandem. (See test 14 and 16)